### PR TITLE
chore(dependabot): change prefix to chore instead of npm and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       time: '09:00'
       timezone: 'America/Sao_Paulo'
     commit-message:
-      prefix: 'npm'
+      prefix: 'chore'
       include: 'scope'
 
   - package-ecosystem: 'docker'
@@ -18,7 +18,7 @@ updates:
       time: '09:00'
       timezone: 'America/Sao_Paulo'
     commit-message:
-      prefix: 'docker'
+      prefix: 'chore'
       include: 'scope'
 
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
## Proposed changes

Change dependabots commit messages prefix to `chore` instead of `npm` and `docker`.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_.

- [x] CI